### PR TITLE
Mention submodules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ SELECT * FROM sqlite_db.tmp;
 
 ## Building & Loading the Extension
 
+>**Tip**:
+>Before building, fetch submodules with `git submodule update --remote`
+
 To build, type 
 ```
 make

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ SELECT * FROM sqlite_db.tmp;
 ## Building & Loading the Extension
 
 >**Tip**:
->Before building, fetch submodules with `git submodule update --init --remote`
+>
+>Before building, fetch submodules with `make pull`
 
 To build, type 
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ SELECT * FROM sqlite_db.tmp;
 ## Building & Loading the Extension
 
 >**Tip**:
->Before building, fetch submodules with `git submodule update --remote`
+>Before building, fetch submodules with `git submodule update --init --remote`
 
 To build, type 
 ```


### PR DESCRIPTION
Without fetching submodules, building fails with this error:

```
aryehh@debian-nix ~/D/duckdb-sqlite (main)> make
Makefile:8: extension-ci-tools/makefiles/duckdb_extension.Makefile: No such file or directory
make: *** No rule to make target 'extension-ci-tools/makefiles/duckdb_extension.Makefile'.  St
```