### PR TITLE
Fix SQLiteInsert to use casted plan instead of raw plan

### DIFF
--- a/src/storage/sqlite_insert.cpp
+++ b/src/storage/sqlite_insert.cpp
@@ -191,7 +191,7 @@ PhysicalOperator &SQLiteCatalog::PlanInsert(ClientContext &context, PhysicalPlan
 	D_ASSERT(plan);
 	auto &inner_plan = AddCastToSQLiteTypes(context, planner, *plan);
 	auto &insert = planner.Make<SQLiteInsert>(op, op.table, op.column_index_map);
-	insert.children.push_back(*plan);
+	insert.children.push_back(inner_plan);
 	return insert;
 }
 


### PR DESCRIPTION
  There appears to be an issue where SQLiteInsert uses the raw plan instead of the type-casted plan. The code calls AddCastToSQLiteTypes to create inner_plan but then uses the original plan:

```cpp
  auto &inner_plan = AddCastToSQLiteTypes(context, planner, *plan);
  auto &insert = planner.Make<SQLiteInsert>(op, op.table, op.column_index_map);
  insert.children.push_back(*plan);  // Should this be inner_plan?
```