### PR TITLE
Fix CI: Add yum support for sqlite3 installation in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 # Setup the sqlite3 tpch database
 data/db/tpch.db: release
-	command -v sqlite3 || (command -v brew && brew install sqlite) || (command -v choco && choco install sqlite -y) || (command -v apt-get && apt-get install -y sqlite3) || (command -v apk && apk add sqlite) || echo "no sqlite3"
+	command -v sqlite3 || (command -v brew && brew install sqlite) || (command -v choco && choco install sqlite -y) || (command -v apt-get && apt-get install -y sqlite3) || (command -v yum && yum install -y sqlite) || (command -v apk && apk add sqlite) || echo "no sqlite3"
 	./build/release/$(DUCKDB_PATH) < data/sql/tpch-export.duckdb || tree ./build/release || echo "neither tree not duck"
 	sqlite3 data/db/tpch.db < data/sql/tpch-create.sqlite
 


### PR DESCRIPTION
This fixes CI failures on Red Hat-based systems by adding yum to the package manager chain for sqlite3 installation.

fixes #160 