### PR TITLE
Add an option to force single-threaded scans

### DIFF
--- a/src/sqlite_extension.cpp
+++ b/src/sqlite_extension.cpp
@@ -37,6 +37,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("sqlite_debug_show_queries", "DEBUG SETTING: print all queries sent to SQLite to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetSqliteDebugQueryPrint);
 
+	config.AddExtensionOption("sqlite_disable_multithreaded_scans", "Make all scans over the SQLite DB to be performed using a single worker thread",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+
 	StorageExtension::Register(config, "sqlite_scanner", make_shared_ptr<SQLiteStorageExtension>());
 }
 

--- a/src/storage/sqlite_table_entry.cpp
+++ b/src/storage/sqlite_table_entry.cpp
@@ -38,15 +38,19 @@ TableFunction SQLiteTableEntry::GetScanFunction(ClientContext &context, unique_p
 		result->rows_per_group = optional_idx();
 	}
 
-	bool use_global_db = !transaction.IsReadOnly() || sqlite_catalog.InMemory();
-
-	Value threads_setting;
-	if (!use_global_db && context.TryGetCurrentSetting("threads", threads_setting) && !threads_setting.IsNull()) {
-		auto current_threads = NumericCast<idx_t>(BigIntValue::Get(threads_setting.DefaultCastAs(LogicalType::BIGINT)));
-		if (current_threads <= 1) {
-			use_global_db = true;
-		}
+	int64_t threads = 1;
+	Value threads_val;
+	if (context.TryGetCurrentSetting("threads", threads_val)) {
+		threads = BigIntValue::Get(threads_val);
 	}
+
+	bool disable_multithreaded_scans = false;
+	Value disable_multithreaded_scans_val;
+	if (context.TryGetCurrentSetting("sqlite_disable_multithreaded_scans", disable_multithreaded_scans_val)) {
+		disable_multithreaded_scans = BooleanValue::Get(disable_multithreaded_scans_val);
+	}
+
+	bool use_global_db = !transaction.IsReadOnly() || sqlite_catalog.InMemory() || threads <= 1 || disable_multithreaded_scans;
 
 	if (use_global_db) {
 		// for in-memory databases or if we have transaction-local changes we can

--- a/test/sql/storage/attach_simple.test
+++ b/test/sql/storage/attach_simple.test
@@ -39,3 +39,16 @@ query I
 SELECT * FROM simple.test2
 ----
 84
+
+# check option is supported
+
+statement ok
+SET sqlite_disable_multithreaded_scans = TRUE;
+
+query I
+SELECT * FROM simple.test2
+----
+84
+
+statement ok
+SET sqlite_disable_multithreaded_scans = FALSE;


### PR DESCRIPTION
This PR is a follow-up to the #179 PR. It adds an option:

```sql
SET sqlite_disable_multithreaded_scans = FALSE;
```

When enabled, it has the same effect on SQLite scans as the setting `threads = 1`;

Testing: basic check added that the option can be set.