### PR TITLE
Fix schema error message

### DIFF
--- a/src/storage/sqlite_catalog.cpp
+++ b/src/storage/sqlite_catalog.cpp
@@ -41,7 +41,7 @@ optional_ptr<SchemaCatalogEntry> SQLiteCatalog::LookupSchema(CatalogTransaction 
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		return nullptr;
 	}
-	throw BinderException("SQLite databases only have a single schema - \"%s\"", DEFAULT_SCHEMA);
+	throw BinderException("SQLite databases only have a single schema - \"%s\"", std::string(DEFAULT_SCHEMA));
 }
 
 bool SQLiteCatalog::InMemory() {


### PR DESCRIPTION
This PR fixes the schema error message that could cause the following double error:

> INTERNAL Error:
> Primary exception: SQLite databases only have a single schema - "%s"
> Secondary exception in ExceptionFormatValue: {"exception_type":"Invalid Input","exception_message":"Invalid type specifier \"s\" for formatting a value of type int"}
> This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
> For more information, see https://duckdb.org/docs/stable/dev/internal_errors

Ref: duckdb/duckdb#21378