### PR TITLE
Optimise get row id info query (1.5)

### DIFF
--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -234,8 +234,9 @@ bool SQLiteDB::ColumnExists(const string &table_name, const string &column_name)
 
 bool SQLiteDB::GetRowIdInfo(const string &table_name, RowIdInfo &row_id_info) {
 	SQLiteStatement stmt;
-	if (!TryPrepare(StringUtil::Format("SELECT MIN(ROWID), MAX(ROWID) FROM \"%s\"",
-	                                   SQLiteUtils::SanitizeIdentifier(table_name)),
+	auto sanitized_table_name = SQLiteUtils::SanitizeIdentifier(table_name);
+	if (!TryPrepare(StringUtil::Format("SELECT (SELECT MIN(ROWID) FROM \"%s\"), (SELECT MAX(ROWID) FROM \"%s\")",
+	                                   sanitized_table_name, sanitized_table_name),
 	                stmt)) {
 		return false;
 	}


### PR DESCRIPTION
This is a backport of the PR #192 to `v1.5-variegata` stable branch.

Sqlite is a lot faster at getting the `MIN(ROWID)` and `MAX(ROWID)` separately, the previous query `SELECT MIN(ROWID)`, `MAX(ROWID) FROM \"%s\"` would cause sqlite to scan the table instead of looking at either end of the B tree. The speed difference is apparent on large tables.