### PR TITLE
Allow copy tables from SQLite to SQLite

### DIFF
--- a/src/storage/sqlite_catalog.cpp
+++ b/src/storage/sqlite_catalog.cpp
@@ -24,6 +24,10 @@ void SQLiteCatalog::Initialize(bool load_builtin) {
 }
 
 optional_ptr<CatalogEntry> SQLiteCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+	if (info.SchemaName() == Identifier::DefaultSchema()) {
+		// CREATE SCHEMA is called when doing COPY DATABASE from SQLite to SQLite
+		return main_schema.get();
+	}
 	throw BinderException("SQLite databases do not support creating new schemas");
 }
 

--- a/test/sql/storage/attach_copy_database.test
+++ b/test/sql/storage/attach_copy_database.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/attach_copy_database.test
+# description: Test copying database (tables only, no indices) into SQLite
+# group: [storage]
+
+require sqlite_scanner
+
+statement ok
+ATTACH ':memory:' AS source (TYPE sqlite);
+
+statement ok
+ATTACH ':memory:' AS target (TYPE sqlite);
+
+statement ok
+CREATE TABLE source.tab1(col1 INT)
+
+statement ok
+INSERT INTO source.tab1(col1) VALUES(42), (43)
+
+statement ok
+COPY FROM DATABASE source TO target
+
+query I
+FROM target.tab1 ORDER BY col1
+----
+42
+43
+
+statement ok
+DETACH target
+
+statement ok
+DETACH source


### PR DESCRIPTION
`COPY DATABASE` to SQLite from DuckDB is partially supported (only tables can be copied, NOT indices). But copying from SQLite to SQLite was failing on schema creation step. SQLite does not have the notion of `SCHEMA`, but SQLite DB attached to DuckDB has an implicit `main` schema.

This PR adds a check that the `main` schema is being created and treats this schema as an existing one.

Note, that copying a database that contains indices to SQLite is NOT supported, this behaviour is consistent between Postgres, MySQL and SQLite scanners.

Ref: #167