### PR TITLE
Test: scans of different same-shape attached tables stay distinct

### DIFF
--- a/test/sql/storage/attach_common_subplan.test
+++ b/test/sql/storage/attach_common_subplan.test
@@ -1,0 +1,40 @@
+# name: test/sql/storage/attach_common_subplan.test
+# description: Scans of different attached tables with identical column layouts must not be merged as common subplans
+# group: [storage]
+
+require sqlite_scanner
+
+statement ok
+ATTACH '{TEST_DIR}/attach_common_subplan.db' AS s (TYPE SQLITE)
+
+statement ok
+CREATE TABLE s.flows (id VARCHAR, source VARCHAR);
+
+statement ok
+CREATE TABLE s.verifiers (id VARCHAR, source VARCHAR);
+
+statement ok
+INSERT INTO s.flows VALUES ('f1', 'file'), ('f2', 'file');
+
+statement ok
+INSERT INTO s.verifiers VALUES ('v1', 'file'), ('v2', 'file'), ('v3', 'file');
+
+query II
+SELECT (SELECT count(*) FROM s.flows WHERE source='file'),
+       (SELECT count(*) FROM s.verifiers WHERE source='file');
+----
+2	3
+
+query II
+SELECT (SELECT string_agg(id, ',' ORDER BY id) FROM s.flows),
+       (SELECT string_agg(id, ',' ORDER BY id) FROM s.verifiers);
+----
+f1,f2	v1,v2,v3
+
+query II
+SELECT 'flow' AS kind, count(*) FROM s.flows WHERE source='file'
+UNION ALL
+SELECT 'verifier', count(*) FROM s.verifiers WHERE source='file';
+----
+flow	2
+verifier	3


### PR DESCRIPTION
Companion test for duckdb/duckdb#24781, fixed by duckdb/duckdb#24782 — kept as a **draft** until that fix reaches this repo's pinned core, because the test fails against the current pin by construction (it pins the bug).

Without the core fix, the `common_subplan` optimizer merges attached-SQLite scans of tables with identical column layouts (the serialized subplan form carries no scan identity for a parameter-less scan without serialization callbacks), and each query in this test returns one table's rows for both subqueries. Verified green against a core build carrying the fix (this repo's build with the patched submodule: the whole `test/sql/storage/*` suite passes, 906+ assertions).