### PR TITLE
Report the extension version when statically linked

### DIFF
--- a/src/include/sqlite_scanner_extension.hpp
+++ b/src/include/sqlite_scanner_extension.hpp
@@ -13,6 +13,7 @@ public:
 	std::string Name() override {
 		return "sqlite_scanner";
 	}
+	std::string Version() const override;
 	void Load(ExtensionLoader &loader) override;
 };
 

--- a/src/sqlite_extension.cpp
+++ b/src/sqlite_extension.cpp
@@ -59,6 +59,14 @@ void SqliteScannerExtension::Load(ExtensionLoader &loader) {
 	LoadInternal(loader);
 }
 
+std::string SqliteScannerExtension::Version() const {
+#ifdef EXT_VERSION_SQLITE_SCANNER
+	return EXT_VERSION_SQLITE_SCANNER;
+#else
+	return "";
+#endif
+}
+
 DUCKDB_CPP_EXTENSION_ENTRY(sqlite_scanner, loader) {
 	LoadInternal(loader);
 }


### PR DESCRIPTION
`SqliteScannerExtension` does not override `Version()`, so the base class returns an empty string and a statically linked build reports no version. `duckdb_extensions()` shows `sqlite_scanner` blank next to `parquet` and `core_functions`. The loadable extension is unaffected, since its version comes from the metadata footer rather than from the class.

DuckDB already supplies the value as `EXT_VERSION_SQLITE_SCANNER`, and the in-tree extensions read it exactly this way. The definition belongs in the `.cpp` rather than the header, because `LoadStaticExtension` is instantiated inside DuckDB's generated loader, which compiles outside the scope where the macro is defined. With this change a statically linked build reports `e444ab4`.

Ref: duckdb/duckdb#24799