### PR TITLE
Move the local state when returning it as the base type

### DIFF
--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -213,14 +213,14 @@ SqliteInitLocalState(ExecutionContext &context, TableFunctionInitInput &input, G
 	auto &gstate = global_state->Cast<SqliteGlobalState>();
 	auto result = make_uniq<SqliteLocalState>();
 	if (bind_data.command_only) {
-		return result;
+		return std::move(result);
 	}
 	result->column_ids = input.column_ids;
 	result->db = bind_data.global_db;
 	if (!SqliteParallelStateNext(context.client, bind_data, *result, gstate)) {
 		result->done = true;
 	}
-	return result;
+	return std::move(result);
 }
 
 static unique_ptr<GlobalTableFunctionState> SqliteInitGlobalState(ClientContext &context,


### PR DESCRIPTION
`SqliteInitLocalState` returns `unique_ptr<SqliteLocalState>` as a `unique_ptr<LocalTableFunctionState>`. DuckDB's `unique_ptr` derives from `std::unique_ptr`, so the constructor selected here takes an rvalue reference to a base class of the returned object's type rather than to its own type. C++20 moves implicitly in that case, but C++17 does not, so `return result;` is ill-formed there. This restores the `std::move` that was on these returns before the `command_only` path was added.

It matters because DuckDB builds statically linked extensions at C++17 (`CMAKE_CXX_STANDARD 17` in its top-level `CMakeLists.txt`), so a `DUCKDB_EXTENSIONS='sqlite_scanner'` build of DuckDB `main` currently fails to compile this file. `std::move` is correct under both standards, so nothing else changes.