### PR TITLE
Opt out of scans serialization (1.5)

### DIFF
--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -371,11 +371,22 @@ SqliteStatistics(ClientContext &context, const FunctionData *bind_data_p,
 }
 */
 
+static void SqliteScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                               const TableFunction &function) {
+	throw NotImplementedException("SqliteScanSerialize");
+}
+
+static unique_ptr<FunctionData> SqliteScanDeserialize(Deserializer &deserializer, TableFunction &function) {
+	throw NotImplementedException("SqliteScanDeserialize");
+}
+
 SqliteScanFunction::SqliteScanFunction()
     : TableFunction("sqlite_scan", {LogicalType::VARCHAR, LogicalType::VARCHAR}, SqliteScan, SqliteBind,
                     SqliteInitGlobalState, SqliteInitLocalState) {
 	cardinality = SqliteCardinality;
 	to_string = SqliteToString;
+	serialize = SqliteScanSerialize;
+	deserialize = SqliteScanDeserialize;
 	get_bind_info = SqliteBindInfo;
 	projection_pushdown = true;
 }

--- a/test/sql/scanner/cte_inlining.test
+++ b/test/sql/scanner/cte_inlining.test
@@ -1,0 +1,21 @@
+# name: test/sql/scanner/cte_inlining.test
+# description: Test serialization problem with CTE inlining
+# group: [scanner]
+
+# https://github.com/duckdb/duckdb-sqlite/issues/212
+
+require sqlite_scanner
+
+statement ok
+ATTACH ':memory:' AS s (TYPE sqlite);
+
+statement ok
+CREATE TABLE s.t(id INTEGER, name TEXT)
+
+query I
+WITH p AS (SELECT id FROM s.t) SELECT * FROM p UNION ALL SELECT * FROM p LIMIT 1;
+----
+
+statement ok
+DETACH
+s


### PR DESCRIPTION
This is a backport of the PR #217 to `v1.5-variegata` stable branch.

Some of the engine optimizers, like CTE inlining, use the serialization/deserialization of the table functions present in the query plan. Serialization callbacks were absent in the SQLite scan so default callbacks were used (that don't include function parameters). The binding is performed after the deserialization (to produce the "bind data" object) and the binding routine in the extension was not prepared to be called without input parameters.

Function can effectively opt-out of serialization/deserialization by throwing `NotImplementedException` (that is checked by optimizers). Postgres and MySQL scanners are doing that. This PR adds such opt-out throwing serializers to this extension.

Fixes: #212