### PR TITLE
Initialize member pointers to nullptr (1.5)

### DIFF
--- a/src/include/sqlite_db.hpp
+++ b/src/include/sqlite_db.hpp
@@ -28,7 +28,7 @@ public:
 	SQLiteDB(SQLiteDB &&other) noexcept;
 	SQLiteDB &operator=(SQLiteDB &&) noexcept;
 
-	sqlite3 *db;
+	sqlite3 *db = nullptr;
 
 public:
 	//! Open a SQLite database (local files only)

--- a/src/include/sqlite_duckdb_vfs_cache.hpp
+++ b/src/include/sqlite_duckdb_vfs_cache.hpp
@@ -103,10 +103,10 @@ public:
 
 // Allocated by SQLite; may cross module boundaries -- raw pointers with explicit ownership.
 struct SQLiteDuckDBCachedFile {
-	sqlite3_file base;             // Must be first member for C compatibility
-	DuckDBCachedFile *duckdb_file; // deleted in Close()
-	DuckDBVFSWrapper *wrapper;     // VFS instance owning the io_methods this file points into;
-	                               // refcounted so the wrapper outlives its open files
+	sqlite3_file base;                       // Must be first member for C compatibility
+	DuckDBCachedFile *duckdb_file = nullptr; // deleted in Close()
+	DuckDBVFSWrapper *wrapper = nullptr;     // VFS instance owning the io_methods this file points into;
+	                                         // refcounted so the wrapper outlives its open files
 };
 
 } // namespace duckdb

--- a/src/include/sqlite_scanner.hpp
+++ b/src/include/sqlite_scanner.hpp
@@ -28,7 +28,7 @@ struct SqliteBindData : public TableFunctionData {
 	bool all_varchar = false;
 
 	optional_idx rows_per_group = 122880;
-	SQLiteDB *global_db;
+	SQLiteDB *global_db = nullptr;
 
 	optional_ptr<TableCatalogEntry> table;
 };

--- a/src/include/sqlite_stmt.hpp
+++ b/src/include/sqlite_stmt.hpp
@@ -27,8 +27,8 @@ public:
 	SQLiteStatement(SQLiteStatement &&other) noexcept;
 	SQLiteStatement &operator=(SQLiteStatement &&) noexcept;
 
-	sqlite3 *db;
-	sqlite3_stmt *stmt;
+	sqlite3 *db = nullptr;
+	sqlite3_stmt *stmt = nullptr;
 
 public:
 	int Step();

--- a/src/include/storage/sqlite_transaction.hpp
+++ b/src/include/storage/sqlite_transaction.hpp
@@ -37,7 +37,7 @@ public:
 
 private:
 	SQLiteCatalog &sqlite_catalog;
-	SQLiteDB *db;
+	SQLiteDB *db = nullptr;
 	SQLiteDB owned_db;
 	unique_ptr<SQLiteCatalogMap> catalog_map;
 

--- a/src/sqlite_duckdb_vfs_cache.cpp
+++ b/src/sqlite_duckdb_vfs_cache.cpp
@@ -49,8 +49,8 @@ namespace duckdb {
 // Per-context VFS instances. vfs_name uses sqlite3_malloc for cross-DLL safety.
 struct DuckDBVFSWrapper {
 	sqlite3_vfs base; // Must be first - SQLite VFS structure
-	ClientContext *context;
-	char *vfs_name;
+	ClientContext *context = nullptr;
+	char *vfs_name = nullptr;
 	sqlite3_io_methods io_methods;
 
 	mutable mutex error_mutex;

--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -18,7 +18,7 @@
 namespace duckdb {
 
 struct SqliteLocalState : public LocalTableFunctionState {
-	SQLiteDB *db;
+	SQLiteDB *db = nullptr;
 	SQLiteDB owned_db;
 	SQLiteStatement stmt;
 	string stmt_sql;

--- a/src/storage/sqlite_insert.cpp
+++ b/src/storage/sqlite_insert.cpp
@@ -30,10 +30,9 @@ SQLiteInsert::SQLiteInsert(PhysicalPlan &physical_plan, LogicalOperator &op, Sch
 //===--------------------------------------------------------------------===//
 class SQLiteInsertGlobalState : public GlobalSinkState {
 public:
-	explicit SQLiteInsertGlobalState(ClientContext &context, SQLiteTableEntry *table) : insert_count(0) {
+	explicit SQLiteInsertGlobalState(ClientContext &context) : insert_count(0) {
 	}
 
-	SQLiteTableEntry *table;
 	SQLiteStatement statement;
 	idx_t insert_count;
 };
@@ -90,7 +89,7 @@ unique_ptr<GlobalSinkState> SQLiteInsert::GetGlobalSinkState(ClientContext &cont
 		insert_table = &table.get_mutable()->Cast<SQLiteTableEntry>();
 	}
 	auto &transaction = SQLiteTransaction::Get(context, insert_table->catalog);
-	auto result = make_uniq<SQLiteInsertGlobalState>(context, insert_table);
+	auto result = make_uniq<SQLiteInsertGlobalState>(context);
 	result->statement = transaction.GetDB().Prepare(GetInsertSQL(*this, insert_table));
 	return std::move(result);
 }


### PR DESCRIPTION
This is a backport of the PR #221 to `v1.5-variegata` stable branch.

This PR adds `nullptr` initalization to member pointers in a number of extension classes.

Fixes: #220