### PR TITLE
Resolve the sqlite_query connection from the executing transaction

### DIFF
--- a/src/include/sqlite_scanner.hpp
+++ b/src/include/sqlite_scanner.hpp
@@ -13,7 +13,6 @@
 #include "storage/sqlite_catalog.hpp"
 
 namespace duckdb {
-class SQLiteDB;
 class TableCatalogEntry;
 
 struct SqliteBindData : public TableFunctionData {
@@ -29,7 +28,6 @@ struct SqliteBindData : public TableFunctionData {
 	bool all_varchar = false;
 
 	optional_idx rows_per_group = 122880;
-	SQLiteDB *global_db = nullptr;
 
 	optional_ptr<TableCatalogEntry> table;
 	bool command_only = false;

--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -158,7 +158,7 @@ static idx_t SqliteMaxThreads(ClientContext &context, const FunctionData *bind_d
 	if (bind_data.command_only) {
 		return 1;
 	}
-	if (bind_data.global_db) {
+	if (bind_data.catalog) {
 		return 1;
 	}
 	if (!bind_data.row_id_info.max_rowid.IsValid()) {
@@ -211,14 +211,17 @@ static bool SqliteParallelStateNext(ClientContext &context, const SqliteBindData
 
 static unique_ptr<LocalTableFunctionState>
 SqliteInitLocalState(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
-	auto &bind_data = input.bind_data->Cast<SqliteBindData>();
+	auto &bind_data = input.bind_data->CastNoConst<SqliteBindData>();
 	auto &gstate = global_state->Cast<SqliteGlobalState>();
 	auto result = make_uniq<SqliteLocalState>();
 	if (bind_data.command_only) {
 		return std::move(result);
 	}
 	result->column_ids = input.column_ids;
-	result->db = bind_data.global_db;
+	if (bind_data.catalog) {
+		// the bind data can outlive the transaction it was bound in (e.g. PREPARE/EXECUTE) - use the current one
+		result->db = &SQLiteTransaction::Get(context.client, *bind_data.catalog).GetDB();
+	}
 	if (!SqliteParallelStateNext(context.client, bind_data, *result, gstate)) {
 		result->done = true;
 	}

--- a/src/storage/sqlite_query.cpp
+++ b/src/storage/sqlite_query.cpp
@@ -83,14 +83,13 @@ static unique_ptr<FunctionData> SQLiteQueryBind(ClientContext &context, TableFun
 		return_types.emplace_back(LogicalType::BIGINT);
 		names.emplace_back("rowcount");
 		result->command_only = true;
-		result->catalog = &sqlite_catalog;
 	}
 	result->rows_per_group = optional_idx();
 	result->sql = std::move(sql);
 	result->params = std::move(params);
 	result->all_varchar = true;
 	result->file_name = sqlite_catalog.GetDBPath();
-	result->global_db = &con;
+	result->catalog = &sqlite_catalog;
 	return std::move(result);
 }
 

--- a/src/storage/sqlite_table_entry.cpp
+++ b/src/storage/sqlite_table_entry.cpp
@@ -55,9 +55,8 @@ TableFunction SQLiteTableEntry::GetScanFunction(ClientContext &context, unique_p
 
 	if (use_global_db) {
 		// for in-memory databases or if we have transaction-local changes we can
-		// only do a single-threaded scan set up the transaction's connection object
-		// as the global db
-		result->global_db = &db;
+		// only do a single-threaded scan using the transaction's connection object
+		result->catalog = &sqlite_catalog;
 		result->rows_per_group = optional_idx();
 	}
 	result->table = this;

--- a/test/sql/storage/attach_sqlite_query.test
+++ b/test/sql/storage/attach_sqlite_query.test
@@ -103,6 +103,23 @@ bazboo
 statement ok
 DEALLOCATE p1
 
+# prepared statement without parameters
+statement ok
+PREPARE p2 AS FROM sqlite_query(sakila, 'SELECT first_name FROM actor WHERE actor_id=1')
+
+query I
+EXECUTE p2
+----
+PENELOPE
+
+query I
+EXECUTE p2
+----
+PENELOPE
+
+statement ok
+DEALLOCATE p2
+
 statement error
 FROM sqlite_query(sakila, 'SELECT ? a', params=row(42::TINYINT))
 ----


### PR DESCRIPTION
Proposed fix for #224

**AI disclosure**: Debugging and implementation were done by an LLM and manually reviewed, but I am not very familiar with the codebase.

LLM generated:

`sqlite_query` stored a pointer to the connection owned by the transaction it was bound in (`SqliteBindData::global_db`). A prepared statement without parameters is bound once and executed in later transactions, so the pointer dangled: on DuckDB 1.4 this surfaced as `Failed to prepare query ...: out of memory` (`sqlite3_errmsg` on the nulled handle of the closed connection), on 1.5 as a segfault. The existing `PREPARE` test did not catch it because its `params=row(?, ?)` forces a rebind on every `EXECUTE`.

The bind data now records the catalog instead, and `SqliteInitLocalState` fetches the connection of the current transaction through `SQLiteTransaction::Get(...).GetDB()`, the same way the command-only path and the DML operators already do. The single-connection table scan path is switched over as well, so `global_db` is removed. `SqliteMaxThreads` keys off `catalog` in the same cases it keyed off `global_db` before.

Overriding `FunctionData::SupportStatementCache()` would also avoid the crash by forcing a rebind on every `EXECUTE`, but that leaves the dangling pointer in place, so resolving the connection at execution time seemed preferable.

Note: a `DETACH` between `PREPARE` and `EXECUTE` still crashes, since the bind data keeps a raw catalog pointer and table functions do not register a database read for rebind checks (pre-existing)

Tested with the repro from the issue, the full test suite and `make format-check`. Added a parameterless `PREPARE`/`EXECUTE` case to `test/sql/storage/attach_sqlite_query.test`.