### PR TITLE
Resolve the sqlite_query connection (1.5)

### DIFF
--- a/src/include/sqlite_scanner.hpp
+++ b/src/include/sqlite_scanner.hpp
@@ -10,9 +10,9 @@
 
 #include "duckdb.hpp"
 #include "sqlite_utils.hpp"
+#include "storage/sqlite_catalog.hpp"
 
 namespace duckdb {
-class SQLiteDB;
 class TableCatalogEntry;
 
 struct SqliteBindData : public TableFunctionData {
@@ -28,9 +28,9 @@ struct SqliteBindData : public TableFunctionData {
 	bool all_varchar = false;
 
 	optional_idx rows_per_group = 122880;
-	SQLiteDB *global_db = nullptr;
 
 	optional_ptr<TableCatalogEntry> table;
+	optional_ptr<SQLiteCatalog> catalog = nullptr;
 };
 
 class SqliteScanFunction : public TableFunction {

--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -15,6 +15,8 @@
 #include "duckdb/common/operator/cast_operators.hpp"
 #include <cmath>
 
+#include "storage/sqlite_transaction.hpp"
+
 namespace duckdb {
 
 struct SqliteLocalState : public LocalTableFunctionState {
@@ -152,7 +154,7 @@ static unique_ptr<NodeStatistics> SqliteCardinality(ClientContext &context, cons
 static idx_t SqliteMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
 	D_ASSERT(bind_data_p);
 	auto &bind_data = bind_data_p->Cast<SqliteBindData>();
-	if (bind_data.global_db) {
+	if (bind_data.catalog) {
 		return 1;
 	}
 	if (!bind_data.row_id_info.max_rowid.IsValid()) {
@@ -205,11 +207,14 @@ static bool SqliteParallelStateNext(ClientContext &context, const SqliteBindData
 
 static unique_ptr<LocalTableFunctionState>
 SqliteInitLocalState(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
-	auto &bind_data = input.bind_data->Cast<SqliteBindData>();
+	auto &bind_data = input.bind_data->CastNoConst<SqliteBindData>();
 	auto &gstate = global_state->Cast<SqliteGlobalState>();
 	auto result = make_uniq<SqliteLocalState>();
 	result->column_ids = input.column_ids;
-	result->db = bind_data.global_db;
+	if (bind_data.catalog) {
+		// the bind data can outlive the transaction it was bound in (e.g. PREPARE/EXECUTE) - use the current one
+		result->db = &SQLiteTransaction::Get(context.client, *bind_data.catalog).GetDB();
+	}
 	if (!SqliteParallelStateNext(context.client, bind_data, *result, gstate)) {
 		result->done = true;
 	}

--- a/src/storage/sqlite_query.cpp
+++ b/src/storage/sqlite_query.cpp
@@ -87,7 +87,7 @@ static unique_ptr<FunctionData> SQLiteQueryBind(ClientContext &context, TableFun
 	result->params = std::move(params);
 	result->all_varchar = true;
 	result->file_name = sqlite_catalog.GetDBPath();
-	result->global_db = &con;
+	result->catalog = &sqlite_catalog;
 	return std::move(result);
 }
 

--- a/src/storage/sqlite_table_entry.cpp
+++ b/src/storage/sqlite_table_entry.cpp
@@ -54,9 +54,8 @@ TableFunction SQLiteTableEntry::GetScanFunction(ClientContext &context, unique_p
 
 	if (use_global_db) {
 		// for in-memory databases or if we have transaction-local changes we can
-		// only do a single-threaded scan set up the transaction's connection object
-		// as the global db
-		result->global_db = &db;
+		// only do a single-threaded scan using the transaction's connection object
+		result->catalog = &sqlite_catalog;
 		result->rows_per_group = optional_idx();
 	}
 	result->table = this;

--- a/test/sql/storage/attach_sqlite_query.test
+++ b/test/sql/storage/attach_sqlite_query.test
@@ -108,6 +108,23 @@ bazboo
 statement ok
 DEALLOCATE p1
 
+# prepared statement without parameters
+statement ok
+PREPARE p2 AS FROM sqlite_query(sakila, 'SELECT first_name FROM actor WHERE actor_id=1')
+
+query I
+EXECUTE p2
+----
+PENELOPE
+
+query I
+EXECUTE p2
+----
+PENELOPE
+
+statement ok
+DEALLOCATE p2
+
 statement error
 SELECT * from sqlite_query(sakila, 'SELECT ? a', params=row(42::TINYINT))
 ----


### PR DESCRIPTION
This is a backport of the PR #225 to `v1.5-variegata` stable branch.

The bind data of sqlite_query held a pointer to the connection owned by the transaction it was bound in. A prepared statement without parameters is bound once and executed in later transactions, so the pointer dangled and EXECUTE failed with "out of memory" or a segfault.

Record the catalog in the bind data instead and fetch the connection of the current transaction when the scan is initialized, as the command-only path already does. This removes the global_db pointer.

Fixes #224