### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: 1ea4954d1c5bed74df5f528123dca9269aa8791b
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       extension_name: sqlite_scanner
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
@@ -26,7 +26,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
-      duckdb_version: 1ea4954d1c5bed74df5f528123dca9269aa8791b
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       extension_name: sqlite_scanner
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=sqlite_scanner
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+# Core extensions that we need for crucial testing
+DEFAULT_TEST_EXTENSION_DEPS=httpfs;
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,15 +8,3 @@ duckdb_extension_load(sqlite_scanner
 # Any extra extensions that should be built
 # e.g.: duckdb_extension_load(json)
 duckdb_extension_load(tpch)
-
-# The remote-SQLite tests need httpfs, pinned to the commit the duckdb engine coordinates with
-# (APPLY_PATCHES applies the engine's bundled httpfs patches for the dev-engine API; engine and httpfs
-# move independently and skew between releases). Skipped on WASM: the remote tests do not run there,
-# and httpfs's OpenSSL dependency does not build for emscripten.
-if(NOT EMSCRIPTEN)
-    duckdb_extension_load(httpfs
-        GIT_URL https://github.com/duckdb/duckdb-httpfs
-        GIT_TAG fafb14f2c899ddfd1998f8adf2e07fbbfd28b3fd
-        APPLY_PATCHES
-    )
-endif()


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:
- `0002-table-catalog-entry-columns.patch`

It also bumps the duckdb submodules and `.github/workflows/MainDistributionPipeline.yml` to v2.0.0.
